### PR TITLE
Add tests and fix token verification logic consistency

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -15,8 +15,11 @@
     backupStaticProperties="false"
 >
     <testsuites>
-        <testsuite name="JuniorFontenele Test Suite">
-            <directory>tests</directory>
+        <testsuite name="Unit">
+            <directory>tests/Unit</directory>
+        </testsuite>
+        <testsuite name="Feature">
+            <directory>tests/Feature</directory>
         </testsuite>
     </testsuites>
     <coverage>

--- a/src/Application/DTOs/Key/KeyResponseDTO.php
+++ b/src/Application/DTOs/Key/KeyResponseDTO.php
@@ -31,7 +31,7 @@ class KeyResponseDTO
             'valid_from' => $this->validFrom->format('Y-m-d H:i:s'),
             'valid_until' => $this->validUntil->format('Y-m-d H:i:s'),
             'is_revoked' => $this->isRevoked,
-            'revoked_at' => $this->revokedAt->format('Y-m-d H:i:s'),
+            'revoked_at' => $this->revokedAt?->format('Y-m-d H:i:s'),
         ];
     }
 }

--- a/src/Domains/IAM/Client/Client.php
+++ b/src/Domains/IAM/Client/Client.php
@@ -24,7 +24,7 @@ class Client
 
     public function clientId(): string
     {
-        return $this->clientId->value;
+        return $this->clientId->value();
     }
 
     public function name(): string

--- a/src/Domains/IAM/Client/ClientId.php
+++ b/src/Domains/IAM/Client/ClientId.php
@@ -9,14 +9,24 @@ use Ramsey\Uuid\Uuid;
 
 class ClientId
 {
-    public readonly string $value;
+    protected readonly string $value;
 
     public function __construct(?string $value = null)
     {
         $this->value = $value ?? Uuid::uuid7()->toString();
 
-        if (! Uuid::isValid($this->value)) {
-            throw ClientIdException::invalidClientId($this->value);
+        if (! Uuid::isValid($this->value())) {
+            throw ClientIdException::invalidClientId($this->value());
         }
+    }
+
+    public function value(): string
+    {
+        return $this->value;
+    }
+
+    public function __toString(): string
+    {
+        return $this->value();
     }
 }

--- a/src/Domains/IAM/Client/ValueObjects/ProvisionToken.php
+++ b/src/Domains/IAM/Client/ValueObjects/ProvisionToken.php
@@ -41,7 +41,7 @@ class ProvisionToken
     public function verify(ProvisionToken|string $userProvidedToken): bool
     {
         if ($userProvidedToken instanceof ProvisionToken) {
-            $userProvidedToken = $userProvidedToken->value();
+            $userProvidedToken = $userProvidedToken->plainValue();
         }
 
         return password_verify($userProvidedToken, $this->value());

--- a/src/Domains/Vault/Hash/Hash.php
+++ b/src/Domains/Vault/Hash/Hash.php
@@ -48,10 +48,4 @@ class Hash
     {
         return $this->revokedAt;
     }
-
-    public function revoke(): void
-    {
-        $this->isRevoked = true;
-        $this->revokedAt = new \DateTimeImmutable();
-    }
 }

--- a/src/Infrastructure/Laravel/Persistence/Eloquent/EloquentHashRepository.php
+++ b/src/Infrastructure/Laravel/Persistence/Eloquent/EloquentHashRepository.php
@@ -6,6 +6,8 @@ namespace JuniorFontenele\LaravelVaultServer\Infrastructure\Laravel\Persistence\
 
 use JuniorFontenele\LaravelVaultServer\Domains\Vault\Hash\Contracts\HashRepositoryInterface;
 use JuniorFontenele\LaravelVaultServer\Domains\Vault\Hash\Hash;
+use JuniorFontenele\LaravelVaultServer\Domains\Vault\Hash\HashId;
+use JuniorFontenele\LaravelVaultServer\Domains\Vault\Hash\ValueObjects\UserId;
 use JuniorFontenele\LaravelVaultServer\Infrastructure\Laravel\Persistence\Models\HashModel;
 
 class EloquentHashRepository implements HashRepositoryInterface
@@ -23,8 +25,8 @@ class EloquentHashRepository implements HashRepositoryInterface
         }
 
         return new Hash(
-            hashId: $nonRevokedHash->id,
-            userId: $nonRevokedHash->user_id,
+            hashId: new HashId($nonRevokedHash->id),
+            userId: new UserId($nonRevokedHash->user_id),
             hash: $nonRevokedHash->hash,
             version: $nonRevokedHash->version,
             isRevoked: $nonRevokedHash->is_revoked,
@@ -71,8 +73,8 @@ class EloquentHashRepository implements HashRepositoryInterface
             ->get()
             ->map(
                 static fn (HashModel $hashModel): Hash => new Hash(
-                    hashId: $hashModel->id,
-                    userId: $hashModel->user_id,
+                    hashId: new HashId($hashModel->id),
+                    userId: new UserId($hashModel->user_id),
                     hash: $hashModel->hash,
                     version: $hashModel->version,
                     isRevoked: $hashModel->is_revoked,
@@ -93,8 +95,8 @@ class EloquentHashRepository implements HashRepositoryInterface
             ->get()
             ->map(
                 static fn (HashModel $hashModel): Hash => new Hash(
-                    hashId: $hashModel->id,
-                    userId: $hashModel->user_id,
+                    hashId: new HashId($hashModel->id),
+                    userId: new UserId($hashModel->user_id),
                     hash: $hashModel->hash,
                     version: $hashModel->version,
                     isRevoked: $hashModel->is_revoked,
@@ -114,8 +116,8 @@ class EloquentHashRepository implements HashRepositoryInterface
             ->get()
             ->map(
                 static fn (HashModel $hashModel): Hash => new Hash(
-                    hashId: $hashModel->id,
-                    userId: $hashModel->user_id,
+                    hashId: new HashId($hashModel->id),
+                    userId: new UserId($hashModel->user_id),
                     hash: $hashModel->hash,
                     version: $hashModel->version,
                     isRevoked: $hashModel->is_revoked,
@@ -134,8 +136,8 @@ class EloquentHashRepository implements HashRepositoryInterface
             ->get()
             ->map(
                 static fn (HashModel $hashModel): Hash => new Hash(
-                    hashId: $hashModel->id,
-                    userId: $hashModel->user_id,
+                    hashId: new HashId($hashModel->id),
+                    userId: new UserId($hashModel->user_id),
                     hash: $hashModel->hash,
                     version: $hashModel->version,
                     isRevoked: $hashModel->is_revoked,

--- a/tests/Feature/ClientManagerServiceTest.php
+++ b/tests/Feature/ClientManagerServiceTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace JuniorFontenele\LaravelVaultServer\Tests\Feature;
+
+use Illuminate\Support\Facades\Event;
+use JuniorFontenele\LaravelVaultServer\Application\DTOs\Client\CreateClientResponseDTO;
+use JuniorFontenele\LaravelVaultServer\Domains\IAM\Client\Exceptions\ClientException;
+use JuniorFontenele\LaravelVaultServer\Infrastructure\Laravel\Facades\VaultClientManager;
+use JuniorFontenele\LaravelVaultServer\Tests\TestCase;
+
+class ClientManagerServiceTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->loadWorkbenchMigrations = true;
+
+        Event::fake();
+    }
+
+    public function testCreateClient(): void
+    {
+        $response = VaultClientManager::createClient(
+            name: 'Test Client',
+            allowedScopes: ['keys:read', 'hashes:read'],
+            description: 'Test description'
+        );
+
+        $this->assertInstanceOf(CreateClientResponseDTO::class, $response);
+        $this->assertEquals('Test Client', $response->name);
+        $this->assertEquals(['keys:read', 'hashes:read'], $response->allowedScopes);
+        $this->assertEquals('Test description', $response->description);
+        $this->assertNotEmpty($response->clientId);
+        $this->assertNotEmpty($response->provisionToken);
+
+        Event::assertDispatched('vault.client.created');
+    }
+
+    public function testGenerateProvisionToken(): void
+    {
+        // Create a client first
+        $client = VaultClientManager::createClient(
+            name: 'Test Client for Token',
+            allowedScopes: ['keys:read']
+        );
+
+        Event::fake(); // Reset event fake to test just the token generation event
+
+        $provisionToken = VaultClientManager::generateProvisionToken($client->clientId);
+
+        $this->assertNotEmpty($provisionToken);
+        $this->assertNotEquals($client->provisionToken, $provisionToken);
+
+        Event::assertDispatched('vault.client.token.generated');
+    }
+
+    public function testGenerateProvisionTokenWithNonExistingClientThrowsException(): void
+    {
+        $this->expectException(ClientException::class);
+
+        VaultClientManager::generateProvisionToken('non-existent-client-id');
+    }
+
+    public function testDeleteClient(): void
+    {
+        // Create a client first
+        $client = VaultClientManager::createClient(
+            name: 'Test Client for Deletion',
+            allowedScopes: ['keys:read']
+        );
+
+        Event::fake(); // Reset event fake to test just the deletion event
+
+        VaultClientManager::deleteClient($client->clientId);
+
+        Event::assertDispatched('vault.client.deleted');
+
+        // Verify client was deleted by trying to generate a token for it
+        $this->expectException(ClientException::class);
+        VaultClientManager::generateProvisionToken($client->clientId);
+    }
+
+    public function testGetAllClients(): void
+    {
+        // Create some clients first
+        VaultClientManager::createClient(
+            name: 'Test Client 1',
+            allowedScopes: ['keys:read']
+        );
+
+        VaultClientManager::createClient(
+            name: 'Test Client 2',
+            allowedScopes: ['hashes:read']
+        );
+
+        $clients = VaultClientManager::getAllClients();
+
+        $this->assertCount(2, $clients);
+        $this->assertEquals('Test Client 1', $clients[0]->name);
+        $this->assertEquals('Test Client 2', $clients[1]->name);
+    }
+}

--- a/tests/Feature/Console/Commands/VaultClientManagementTest.php
+++ b/tests/Feature/Console/Commands/VaultClientManagementTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace JuniorFontenele\LaravelVaultServer\Tests\Feature\Console\Commands;
+
+use Illuminate\Support\Facades\Artisan;
+use JuniorFontenele\LaravelVaultServer\Infrastructure\Laravel\Facades\VaultClientManager;
+use JuniorFontenele\LaravelVaultServer\Tests\TestCase;
+
+class VaultClientManagementTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->loadWorkbenchMigrations = true;
+    }
+
+    public function testCreateClientCommand(): void
+    {
+        $this->artisan('vault:client', [
+            'action' => 'create',
+            '--name' => 'Test Client',
+            '--description' => 'Test Description',
+            '--scopes' => 'keys:read,hashes:read',
+        ])
+            ->expectsOutput('Client \'Test Client\' created successfully.')
+            ->expectsOutputToContain('Client ID:')
+            ->expectsOutputToContain('Provision Token:')
+            ->assertExitCode(0);
+
+        // Verify client was created
+        $clients = VaultClientManager::getAllClients();
+        $this->assertCount(1, $clients);
+        $this->assertEquals('Test Client', $clients[0]->name);
+        $this->assertEquals('Test Description', $clients[0]->description);
+        $this->assertEquals(['keys:read', 'hashes:read'], $clients[0]->allowedScopes);
+    }
+
+    public function testListClientsCommand(): void
+    {
+        // Create some clients first
+        VaultClientManager::createClient(
+            name: 'Test Client 1',
+            allowedScopes: ['keys:read'],
+            description: 'CreateClient1',
+        );
+
+        VaultClientManager::createClient(
+            name: 'Test Client 2',
+            allowedScopes: ['hashes:read'],
+            description: 'CreateClient2',
+        );
+
+        $this->withoutMockingConsoleOutput();
+        $this->artisan('vault:client', [
+            'action' => 'list',
+        ]);
+
+        $output = Artisan::output();
+        $this->assertStringContainsString('Test Client 1', $output);
+        $this->assertStringContainsString('Test Client 2', $output);
+        $this->assertStringContainsString('CreateClient1', $output);
+        $this->assertStringContainsString('CreateClient2', $output);
+        $this->assertStringContainsString('keys:read', $output);
+        $this->assertStringContainsString('hashes:read', $output);
+    }
+
+    public function testDeleteClientCommand(): void
+    {
+        // Create a client first
+        $client = VaultClientManager::createClient(
+            name: 'Test Client for Deletion',
+            allowedScopes: ['keys:read']
+        );
+
+        $this->artisan('vault:client', [
+            'action' => 'delete',
+            '--client' => $client->clientId,
+        ])
+            ->expectsOutput("Client with UUID {$client->clientId} deleted successfully.")
+            ->assertExitCode(0);
+
+        // Verify client was deleted
+        $clients = VaultClientManager::getAllClients();
+        $this->assertCount(0, $clients);
+    }
+
+    public function testProvisionClientCommand(): void
+    {
+        // Create a client first
+        $client = VaultClientManager::createClient(
+            name: 'Test Client for Provision',
+            allowedScopes: ['keys:read']
+        );
+
+        // Provision and get token
+        $this->artisan('vault:client', [
+            'action' => 'provision',
+            '--client' => $client->clientId,
+        ])
+            ->expectsOutput("Client ID: {$client->clientId}")
+            ->expectsOutputToContain('Provision Token:')
+            ->assertExitCode(0);
+    }
+
+    public function testCleanupClientsWithNoInactiveClients(): void
+    {
+        $this->artisan('vault:client', [
+            'action' => 'cleanup',
+        ])
+            ->expectsOutput('No inactive clients found.')
+            ->assertExitCode(0);
+    }
+}

--- a/tests/Feature/Http/Controllers/ClientControllerTest.php
+++ b/tests/Feature/Http/Controllers/ClientControllerTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace JuniorFontenele\LaravelVaultServer\Tests\Feature\Http\Controllers;
+
+use Illuminate\Support\Facades\Event;
+use JuniorFontenele\LaravelVaultServer\Infrastructure\Laravel\Facades\VaultClientManager;
+use JuniorFontenele\LaravelVaultServer\Tests\TestCase;
+
+class ClientControllerTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->loadWorkbenchMigrations = true;
+
+        Event::fake();
+    }
+
+    public function testProvisionClient(): void
+    {
+        // Create a client first
+        $client = VaultClientManager::createClient(
+            name: 'Test Client',
+            allowedScopes: ['keys:read', 'hashes:read']
+        );
+
+        $response = $this->postJson(route('vault.client.provision', [$client->clientId]), [
+            'provision_token' => $client->provisionToken,
+        ]);
+
+        $response->assertStatus(201)
+            ->assertJsonStructure([
+                'key_id',
+                'client_id',
+                'public_key',
+                'private_key',
+                'version',
+                'valid_from',
+                'valid_until',
+            ]);
+
+        Event::assertDispatched('vault.client.provisioned');
+    }
+
+    public function testProvisionClientWithInvalidToken(): void
+    {
+        // Create a client first
+        $client = VaultClientManager::createClient(
+            name: 'Test Client',
+            allowedScopes: ['keys:read', 'hashes:read']
+        );
+
+        $response = $this->postJson(route('vault.client.provision', [$client->clientId]), [
+            'provision_token' => 'invalid-token',
+        ]);
+
+        $response->assertStatus(422)
+            ->assertJsonStructure(['error']);
+    }
+
+    public function testProvisionClientWithNonExistingClient(): void
+    {
+        $response = $this->postJson(route('vault.client.provision', ['non-existent-client']), [
+            'provision_token' => 'some-token',
+        ]);
+
+        $response->assertStatus(422)
+            ->assertJsonStructure(['error']);
+    }
+
+    public function testProvisionClientWithoutToken(): void
+    {
+        // Create a client first
+        $client = VaultClientManager::createClient(
+            name: 'Test Client',
+            allowedScopes: ['keys:read', 'hashes:read']
+        );
+
+        $response = $this->postJson(route('vault.client.provision', [$client->clientId]), []);
+
+        $response->assertStatus(422)
+            ->assertJsonStructure(['error']);
+    }
+}

--- a/tests/Feature/Http/Controllers/HashControllerTest.php
+++ b/tests/Feature/Http/Controllers/HashControllerTest.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace JuniorFontenele\LaravelVaultServer\Tests\Feature\Http\Controllers;
+
+use JuniorFontenele\LaravelVaultServer\Tests\TestCase;
+use Ramsey\Uuid\Uuid;
+
+class HashControllerTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->loadWorkbenchMigrations = true;
+
+        $this->updateAuthorizationHeaders();
+    }
+
+    public function testStoreHash(): void
+    {
+        $userId = Uuid::uuid4()->toString();
+        $hash = 'hash-value-for-testing';
+
+        $response = $this->postJson(route('vault.hash.store', [$userId]), [
+            'hash' => $hash,
+        ]);
+
+        $response->assertStatus(201)
+            ->assertJsonStructure([
+                'hash_id',
+                'user_id',
+                'hash',
+                'version',
+                'is_revoked',
+            ])
+            ->assertJson([
+                'user_id' => $userId,
+                'hash' => $hash,
+                'version' => 1,
+                'is_revoked' => false,
+            ]);
+    }
+
+    public function testShowHash(): void
+    {
+        $userId = Uuid::uuid4()->toString();
+        $hash = 'hash-value-for-testing';
+
+        // Store hash first
+        $this->postJson(route('vault.hash.store', [$userId]), [
+            'hash' => $hash,
+        ]);
+
+        $this->updateAuthorizationHeaders();
+
+        $response = $this->getJson(route('vault.hash.get', [$userId]));
+
+        $response->assertStatus(200)
+            ->assertJsonStructure([
+                'hash_id',
+                'user_id',
+                'hash',
+                'version',
+                'is_revoked',
+            ])
+            ->assertJson([
+                'user_id' => $userId,
+                'hash' => $hash,
+                'version' => 1,
+                'is_revoked' => false,
+            ]);
+    }
+
+    public function testShowHashWithNonExistingUser(): void
+    {
+        $userId = Uuid::uuid4()->toString();
+
+        $response = $this->getJson(route('vault.hash.get', [$userId]));
+
+        $response->assertStatus(404)
+            ->assertJsonStructure(['error']);
+    }
+
+    public function testDeleteHash(): void
+    {
+        $userId = Uuid::uuid4()->toString();
+        $hash = 'hash-value-for-testing';
+
+        // Store hash first
+        $this->postJson(route('vault.hash.store', [$userId]), [
+            'hash' => $hash,
+        ]);
+
+        $this->updateAuthorizationHeaders();
+
+        $response = $this->deleteJson(route('vault.hash.destroy', [$userId]));
+
+        $response->assertStatus(204);
+
+        $this->updateAuthorizationHeaders();
+
+        // Verify hash was deleted
+        $checkResponse = $this->getJson(route('vault.hash.get', [$userId]));
+        $checkResponse->assertStatus(404);
+    }
+
+    public function testStoreHashWithoutHash(): void
+    {
+        $userId = Uuid::uuid4()->toString();
+
+        $response = $this->postJson(route('vault.hash.store', [$userId]), []);
+
+        $response->assertStatus(422)
+            ->assertJsonStructure(['error']);
+    }
+
+    public function testStoreHashWithInvalidHash(): void
+    {
+        $userId = Uuid::uuid4()->toString();
+
+        // Create a string longer than 255 characters
+        $hash = str_repeat('a', 300);
+
+        $response = $this->postJson(route('vault.hash.store', [$userId]), [
+            'hash' => $hash,
+        ]);
+
+        $response->assertStatus(422)
+            ->assertJsonStructure(['error']);
+    }
+}

--- a/tests/Feature/Http/Controllers/KmsControllerTest.php
+++ b/tests/Feature/Http/Controllers/KmsControllerTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace JuniorFontenele\LaravelVaultServer\Tests\Feature\Http\Controllers;
+
+use JuniorFontenele\LaravelVaultServer\Infrastructure\Laravel\Facades\VaultClientManager;
+use JuniorFontenele\LaravelVaultServer\Tests\TestCase;
+
+class KmsControllerTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->loadWorkbenchMigrations = true;
+
+        $this->updateAuthorizationHeaders();
+    }
+
+    private function createClientAndProvision(): array
+    {
+        $client = VaultClientManager::createClient(
+            name: 'Test Client',
+            allowedScopes: ['keys:read', 'keys:rotate']
+        );
+
+        $response = $this->postJson(route('vault.client.provision', [$client->clientId]), [
+            'provision_token' => $client->provisionToken,
+        ]);
+
+        $keyData = $response->json();
+
+        return [
+            'client' => $client,
+            'key' => $keyData,
+        ];
+    }
+
+    public function testShowKey(): void
+    {
+        $data = $this->createClientAndProvision();
+
+        $response = $this->getJson(route('vault.kms.get', [$data['key']['key_id']]));
+
+        $response->assertStatus(200)
+            ->assertJsonStructure([
+                'key_id',
+                'client_id',
+                'public_key',
+                'version',
+                'valid_from',
+                'valid_until',
+                'is_revoked',
+            ])
+            ->assertJson([
+                'key_id' => $data['key']['key_id'],
+                'client_id' => $data['client']->clientId,
+                'is_revoked' => false,
+            ]);
+    }
+
+    public function testRotateKey(): void
+    {
+        $data = $this->createClientAndProvision();
+
+        $response = $this->postJson(route('vault.kms.rotate', [$data['key']['key_id']]));
+
+        $response->assertStatus(201)
+            ->assertJsonStructure([
+                'key_id',
+                'client_id',
+                'public_key',
+                'version',
+                'valid_from',
+                'valid_until',
+            ])
+            ->assertJson([
+                'client_id' => $data['client']->clientId,
+                'version' => 2, // Version should be incremented
+            ]);
+
+        // The original key should now be revoked
+        $checkOldKey = $this->getJson(uri: route('vault.kms.get', [$data['key']['key_id']]));
+        $checkOldKey->assertStatus(200)
+            ->assertJson([
+                'key_id' => $data['key']['key_id'],
+                'is_revoked' => true,
+            ]);
+    }
+
+    public function testShowKeyWithNonExistingKey(): void
+    {
+        $response = $this->getJson(route('vault.kms.get', ['non-existent-key']));
+
+        $response->assertStatus(404)
+            ->assertJsonStructure(['message']);
+    }
+
+    public function testRotateKeyWithNonExistingKey(): void
+    {
+        $response = $this->postJson(route('vault.kms.rotate', ['non-existent-key']));
+
+        $response->assertStatus(404)
+            ->assertJsonStructure(['message']);
+    }
+}

--- a/tests/Feature/LaravelVaultServerServiceProviderTest.php
+++ b/tests/Feature/LaravelVaultServerServiceProviderTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace JuniorFontenele\LaravelVaultServer\Tests\Feature;
+
+use Illuminate\Routing\Router;
+use JuniorFontenele\LaravelVaultServer\Domains\IAM\Client\Contracts\ClientRepositoryInterface;
+use JuniorFontenele\LaravelVaultServer\Domains\Shared\Contracts\UnitOfWorkInterface;
+use JuniorFontenele\LaravelVaultServer\Domains\Vault\Hash\Contracts\HashRepositoryInterface;
+use JuniorFontenele\LaravelVaultServer\Domains\Vault\Key\Contracts\KeyRepositoryInterface;
+use JuniorFontenele\LaravelVaultServer\Infrastructure\Laravel\Facades\VaultClientManager;
+use JuniorFontenele\LaravelVaultServer\Infrastructure\Laravel\Facades\VaultJWT;
+use JuniorFontenele\LaravelVaultServer\Infrastructure\Laravel\Facades\VaultKey;
+use JuniorFontenele\LaravelVaultServer\Infrastructure\Laravel\Interfaces\Http\Middlewares\ValidateJwtToken;
+use JuniorFontenele\LaravelVaultServer\Infrastructure\Laravel\Persistence\Eloquent\EloquentClientRepository;
+use JuniorFontenele\LaravelVaultServer\Infrastructure\Laravel\Persistence\Eloquent\EloquentHashRepository;
+use JuniorFontenele\LaravelVaultServer\Infrastructure\Laravel\Persistence\Eloquent\EloquentKeyRepository;
+use JuniorFontenele\LaravelVaultServer\Infrastructure\Laravel\Persistence\LaravelUnitOfWork;
+use JuniorFontenele\LaravelVaultServer\Infrastructure\Laravel\Services\ClientManagerService;
+use JuniorFontenele\LaravelVaultServer\Infrastructure\Laravel\Services\JwtService;
+use JuniorFontenele\LaravelVaultServer\Infrastructure\Laravel\Services\KeyPairService;
+use JuniorFontenele\LaravelVaultServer\Tests\TestCase;
+
+class LaravelVaultServerServiceProviderTest extends TestCase
+{
+    public function testServiceProviderBindings(): void
+    {
+        $this->assertTrue($this->app->bound(ClientRepositoryInterface::class));
+        $this->assertTrue($this->app->bound(KeyRepositoryInterface::class));
+        $this->assertTrue($this->app->bound(HashRepositoryInterface::class));
+        $this->assertTrue($this->app->bound(UnitOfWorkInterface::class));
+
+        $this->assertInstanceOf(
+            EloquentClientRepository::class,
+            $this->app->make(ClientRepositoryInterface::class)
+        );
+
+        $this->assertInstanceOf(
+            EloquentKeyRepository::class,
+            $this->app->make(KeyRepositoryInterface::class)
+        );
+
+        $this->assertInstanceOf(
+            EloquentHashRepository::class,
+            $this->app->make(HashRepositoryInterface::class)
+        );
+
+        $this->assertInstanceOf(
+            LaravelUnitOfWork::class,
+            $this->app->make(UnitOfWorkInterface::class)
+        );
+    }
+
+    public function testFacadesAreRegistered(): void
+    {
+        $this->assertTrue(class_exists('VaultKey'));
+        $this->assertTrue(class_exists('VaultClientManager'));
+        $this->assertTrue(class_exists('VaultJWT'));
+
+        $this->assertEquals(KeyPairService::class, get_class(VaultKey::getFacadeRoot()));
+        $this->assertEquals(ClientManagerService::class, get_class(VaultClientManager::getFacadeRoot()));
+        $this->assertEquals(JwtService::class, get_class(VaultJWT::getFacadeRoot()));
+    }
+
+    public function testMiddlewareRegistration(): void
+    {
+        /** @var Router $router */
+        $router = $this->app->make(Router::class);
+        $middlewareAliases = $router->getMiddleware();
+
+        $this->assertArrayHasKey('vault.jwt', $middlewareAliases);
+        $this->assertEquals(ValidateJwtToken::class, $middlewareAliases['vault.jwt']);
+    }
+
+    public function testConfigIsLoaded(): void
+    {
+        $this->assertTrue($this->app['config']->has('vault'));
+    }
+}

--- a/tests/Unit/Application/UseCases/Client/CreateClientUseCaseTest.php
+++ b/tests/Unit/Application/UseCases/Client/CreateClientUseCaseTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace JuniorFontenele\LaravelVaultServer\Tests\Unit\Application\UseCases\Client;
+
+use JuniorFontenele\LaravelVaultServer\Application\DTOs\Client\CreateClientDTO;
+use JuniorFontenele\LaravelVaultServer\Application\DTOs\Client\CreateClientResponseDTO;
+use JuniorFontenele\LaravelVaultServer\Application\UseCases\Client\CreateClientUseCase;
+use JuniorFontenele\LaravelVaultServer\Domains\IAM\Client\Client;
+use JuniorFontenele\LaravelVaultServer\Domains\IAM\Client\Contracts\ClientRepositoryInterface;
+use JuniorFontenele\LaravelVaultServer\Tests\TestCase;
+use Mockery;
+use Mockery\MockInterface;
+
+class CreateClientUseCaseTest extends TestCase
+{
+    private ClientRepositoryInterface|MockInterface $clientRepository;
+
+    private CreateClientUseCase $useCase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->clientRepository = Mockery::mock(ClientRepositoryInterface::class);
+        $this->useCase = new CreateClientUseCase($this->clientRepository);
+    }
+
+    public function testExecute(): void
+    {
+        $this->clientRepository
+            ->shouldReceive('save')
+            ->once()
+            ->with(Mockery::type(Client::class))
+            ->andReturnNull();
+
+        $dto = new CreateClientDTO(
+            name: 'Test Client',
+            allowedScopes: ['keys:read', 'hashes:read'],
+            description: 'Test description'
+        );
+
+        $response = $this->useCase->execute($dto);
+
+        $this->assertInstanceOf(CreateClientResponseDTO::class, $response);
+        $this->assertEquals('Test Client', $response->name);
+        $this->assertEquals(['keys:read', 'hashes:read'], $response->allowedScopes);
+        $this->assertEquals('Test description', $response->description);
+        $this->assertNotEmpty($response->clientId);
+        $this->assertNotEmpty($response->provisionToken);
+    }
+}

--- a/tests/Unit/Application/UseCases/Client/DeleteClientUseCaseTest.php
+++ b/tests/Unit/Application/UseCases/Client/DeleteClientUseCaseTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace JuniorFontenele\LaravelVaultServer\Tests\Unit\Application\UseCases\Client;
+
+use JuniorFontenele\LaravelVaultServer\Application\UseCases\Client\DeleteClientUseCase;
+use JuniorFontenele\LaravelVaultServer\Domains\IAM\Client\Client;
+use JuniorFontenele\LaravelVaultServer\Domains\IAM\Client\Contracts\ClientRepositoryInterface;
+use JuniorFontenele\LaravelVaultServer\Domains\IAM\Client\Exceptions\ClientException;
+use JuniorFontenele\LaravelVaultServer\Tests\TestCase;
+use Mockery;
+use Mockery\MockInterface;
+
+class DeleteClientUseCaseTest extends TestCase
+{
+    private ClientRepositoryInterface|MockInterface $clientRepository;
+
+    private DeleteClientUseCase $useCase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->clientRepository = Mockery::mock(ClientRepositoryInterface::class);
+        $this->useCase = new DeleteClientUseCase($this->clientRepository);
+    }
+
+    public function testExecuteSuccess(): void
+    {
+        $client = Mockery::mock(Client::class);
+
+        $this->clientRepository
+            ->shouldReceive('findClientByClientId')
+            ->once()
+            ->with('test-client-id')
+            ->andReturn($client);
+
+        $this->clientRepository
+            ->shouldReceive('delete')
+            ->once()
+            ->with($client)
+            ->andReturnNull();
+
+        $this->useCase->execute('test-client-id');
+
+        // If no exception is thrown, the test is successful
+        $this->assertTrue(true);
+    }
+
+    public function testExecuteWithNonExistingClientThrowsException(): void
+    {
+        $this->clientRepository
+            ->shouldReceive('findClientByClientId')
+            ->once()
+            ->with('non-existing-id')
+            ->andReturnNull();
+
+        $this->expectException(ClientException::class);
+
+        $this->useCase->execute('non-existing-id');
+    }
+}

--- a/tests/Unit/Application/UseCases/Client/DeleteInactiveClientsUseCaseTest.php
+++ b/tests/Unit/Application/UseCases/Client/DeleteInactiveClientsUseCaseTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace JuniorFontenele\LaravelVaultServer\Tests\Unit\Application\UseCases\Client;
+
+use JuniorFontenele\LaravelVaultServer\Application\DTOs\Client\ClientResponseDTO;
+use JuniorFontenele\LaravelVaultServer\Application\UseCases\Client\DeleteInactiveClientsUseCase;
+use JuniorFontenele\LaravelVaultServer\Domains\IAM\Client\Client;
+use JuniorFontenele\LaravelVaultServer\Domains\IAM\Client\Contracts\ClientRepositoryInterface;
+use JuniorFontenele\LaravelVaultServer\Tests\TestCase;
+use Mockery;
+use Mockery\MockInterface;
+
+class DeleteInactiveClientsUseCaseTest extends TestCase
+{
+    private ClientRepositoryInterface|MockInterface $clientRepository;
+
+    private DeleteInactiveClientsUseCase $useCase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->clientRepository = Mockery::mock(ClientRepositoryInterface::class);
+        $this->useCase = new DeleteInactiveClientsUseCase($this->clientRepository);
+    }
+
+    public function testExecute(): void
+    {
+        $client1 = Mockery::mock(Client::class);
+        $client1->shouldReceive('clientId')->andReturn('client-id-1');
+        $client1->shouldReceive('name')->andReturn('Client 1');
+        $client1->shouldReceive('scopes')->andReturn(['keys:read']);
+        $client1->shouldReceive('description')->andReturn('Description 1');
+
+        $client2 = Mockery::mock(Client::class);
+        $client2->shouldReceive('clientId')->andReturn('client-id-2');
+        $client2->shouldReceive('name')->andReturn('Client 2');
+        $client2->shouldReceive('scopes')->andReturn(['keys:read', 'hashes:read']);
+        $client2->shouldReceive('description')->andReturn('Description 2');
+
+        $inactiveClients = [$client1, $client2];
+
+        $this->clientRepository
+            ->shouldReceive('findAllInactiveClients')
+            ->once()
+            ->andReturn($inactiveClients);
+
+        $this->clientRepository
+            ->shouldReceive('deleteAllInactiveClients')
+            ->once()
+            ->andReturnNull();
+
+        $result = $this->useCase->execute();
+
+        $this->assertCount(2, $result);
+        $this->assertContainsOnlyInstancesOf(ClientResponseDTO::class, $result);
+        $this->assertEquals('client-id-1', $result[0]->clientId);
+        $this->assertEquals('Client 1', $result[0]->name);
+        $this->assertEquals(['keys:read'], $result[0]->allowedScopes);
+        $this->assertEquals('Description 1', $result[0]->description);
+
+        $this->assertEquals('client-id-2', $result[1]->clientId);
+        $this->assertEquals('Client 2', $result[1]->name);
+        $this->assertEquals(['keys:read', 'hashes:read'], $result[1]->allowedScopes);
+        $this->assertEquals('Description 2', $result[1]->description);
+    }
+}

--- a/tests/Unit/Application/UseCases/Client/FindAllActiveClientsUseCaseTest.php
+++ b/tests/Unit/Application/UseCases/Client/FindAllActiveClientsUseCaseTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace JuniorFontenele\LaravelVaultServer\Tests\Unit\Application\UseCases\Client;
+
+use JuniorFontenele\LaravelVaultServer\Application\DTOs\Client\ClientResponseDTO;
+use JuniorFontenele\LaravelVaultServer\Application\UseCases\Client\FindAllActiveClientsUseCase;
+use JuniorFontenele\LaravelVaultServer\Domains\IAM\Client\Client;
+use JuniorFontenele\LaravelVaultServer\Domains\IAM\Client\Contracts\ClientRepositoryInterface;
+use JuniorFontenele\LaravelVaultServer\Tests\TestCase;
+use Mockery;
+use Mockery\MockInterface;
+
+class FindAllActiveClientsUseCaseTest extends TestCase
+{
+    private ClientRepositoryInterface|MockInterface $clientRepository;
+
+    private FindAllActiveClientsUseCase $useCase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->clientRepository = Mockery::mock(ClientRepositoryInterface::class);
+        $this->useCase = new FindAllActiveClientsUseCase($this->clientRepository);
+    }
+
+    public function testExecute(): void
+    {
+        $client1 = Mockery::mock(Client::class);
+        $client1->shouldReceive('clientId')->andReturn('client-id-1');
+        $client1->shouldReceive('name')->andReturn('Client 1');
+        $client1->shouldReceive('scopes')->andReturn(['keys:read']);
+        $client1->shouldReceive('description')->andReturn('Description 1');
+
+        $client2 = Mockery::mock(Client::class);
+        $client2->shouldReceive('clientId')->andReturn('client-id-2');
+        $client2->shouldReceive('name')->andReturn('Client 2');
+        $client2->shouldReceive('scopes')->andReturn(['keys:read', 'hashes:read']);
+        $client2->shouldReceive('description')->andReturn('Description 2');
+
+        $activeClients = [$client1, $client2];
+
+        $this->clientRepository
+            ->shouldReceive('findAllActiveClients')
+            ->once()
+            ->andReturn($activeClients);
+
+        $result = $this->useCase->execute();
+
+        $this->assertCount(2, $result);
+        $this->assertContainsOnlyInstancesOf(ClientResponseDTO::class, $result);
+        $this->assertEquals('client-id-1', $result[0]->clientId);
+        $this->assertEquals('Client 1', $result[0]->name);
+        $this->assertEquals(['keys:read'], $result[0]->allowedScopes);
+        $this->assertEquals('Description 1', $result[0]->description);
+
+        $this->assertEquals('client-id-2', $result[1]->clientId);
+        $this->assertEquals('Client 2', $result[1]->name);
+        $this->assertEquals(['keys:read', 'hashes:read'], $result[1]->allowedScopes);
+        $this->assertEquals('Description 2', $result[1]->description);
+    }
+}

--- a/tests/Unit/Application/UseCases/Client/FindAllClientsUseCaseTest.php
+++ b/tests/Unit/Application/UseCases/Client/FindAllClientsUseCaseTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace JuniorFontenele\LaravelVaultServer\Tests\Unit\Application\UseCases\Client;
+
+use JuniorFontenele\LaravelVaultServer\Application\DTOs\Client\ClientResponseDTO;
+use JuniorFontenele\LaravelVaultServer\Application\UseCases\Client\FindAllClientsUseCase;
+use JuniorFontenele\LaravelVaultServer\Domains\IAM\Client\Client;
+use JuniorFontenele\LaravelVaultServer\Domains\IAM\Client\Contracts\ClientRepositoryInterface;
+use JuniorFontenele\LaravelVaultServer\Tests\TestCase;
+use Mockery;
+use Mockery\MockInterface;
+
+class FindAllClientsUseCaseTest extends TestCase
+{
+    private ClientRepositoryInterface|MockInterface $clientRepository;
+
+    private FindAllClientsUseCase $useCase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->clientRepository = Mockery::mock(ClientRepositoryInterface::class);
+        $this->useCase = new FindAllClientsUseCase($this->clientRepository);
+    }
+
+    public function testExecute(): void
+    {
+        $client1 = Mockery::mock(Client::class);
+        $client1->shouldReceive('clientId')->andReturn('client-id-1');
+        $client1->shouldReceive('name')->andReturn('Client 1');
+        $client1->shouldReceive('scopes')->andReturn(['keys:read']);
+        $client1->shouldReceive('description')->andReturn('Description 1');
+
+        $client2 = Mockery::mock(Client::class);
+        $client2->shouldReceive('clientId')->andReturn('client-id-2');
+        $client2->shouldReceive('name')->andReturn('Client 2');
+        $client2->shouldReceive('scopes')->andReturn(['keys:read', 'hashes:read']);
+        $client2->shouldReceive('description')->andReturn('Description 2');
+
+        $allClients = [$client1, $client2];
+
+        $this->clientRepository
+            ->shouldReceive('findAllClients')
+            ->once()
+            ->andReturn($allClients);
+
+        $result = $this->useCase->execute();
+
+        $this->assertCount(2, $result);
+        $this->assertContainsOnlyInstancesOf(ClientResponseDTO::class, $result);
+        $this->assertEquals('client-id-1', $result[0]->clientId);
+        $this->assertEquals('Client 1', $result[0]->name);
+        $this->assertEquals(['keys:read'], $result[0]->allowedScopes);
+        $this->assertEquals('Description 1', $result[0]->description);
+
+        $this->assertEquals('client-id-2', $result[1]->clientId);
+        $this->assertEquals('Client 2', $result[1]->name);
+        $this->assertEquals(['keys:read', 'hashes:read'], $result[1]->allowedScopes);
+        $this->assertEquals('Description 2', $result[1]->description);
+    }
+}

--- a/tests/Unit/Application/UseCases/Client/FindAllInactiveClientsUseCaseTest.php
+++ b/tests/Unit/Application/UseCases/Client/FindAllInactiveClientsUseCaseTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace JuniorFontenele\LaravelVaultServer\Tests\Unit\Application\UseCases\Client;
+
+use JuniorFontenele\LaravelVaultServer\Application\DTOs\Client\ClientResponseDTO;
+use JuniorFontenele\LaravelVaultServer\Application\UseCases\Client\FindAllInactiveClientsUseCase;
+use JuniorFontenele\LaravelVaultServer\Domains\IAM\Client\Client;
+use JuniorFontenele\LaravelVaultServer\Domains\IAM\Client\Contracts\ClientRepositoryInterface;
+use JuniorFontenele\LaravelVaultServer\Tests\TestCase;
+use Mockery;
+use Mockery\MockInterface;
+
+class FindAllInactiveClientsUseCaseTest extends TestCase
+{
+    private ClientRepositoryInterface|MockInterface $clientRepository;
+
+    private FindAllInactiveClientsUseCase $useCase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->clientRepository = Mockery::mock(ClientRepositoryInterface::class);
+        $this->useCase = new FindAllInactiveClientsUseCase($this->clientRepository);
+    }
+
+    public function testExecute(): void
+    {
+        $client1 = Mockery::mock(Client::class);
+        $client1->shouldReceive('clientId')->andReturn('client-id-1');
+        $client1->shouldReceive('name')->andReturn('Client 1');
+        $client1->shouldReceive('scopes')->andReturn(['keys:read']);
+        $client1->shouldReceive('description')->andReturn('Description 1');
+
+        $client2 = Mockery::mock(Client::class);
+        $client2->shouldReceive('clientId')->andReturn('client-id-2');
+        $client2->shouldReceive('name')->andReturn('Client 2');
+        $client2->shouldReceive('scopes')->andReturn(['keys:read', 'hashes:read']);
+        $client2->shouldReceive('description')->andReturn('Description 2');
+
+        $inactiveClients = [$client1, $client2];
+
+        $this->clientRepository
+            ->shouldReceive('findAllInactiveClients')
+            ->once()
+            ->andReturn($inactiveClients);
+
+        $result = $this->useCase->execute();
+
+        $this->assertCount(2, $result);
+        $this->assertContainsOnlyInstancesOf(ClientResponseDTO::class, $result);
+        $this->assertEquals('client-id-1', $result[0]->clientId);
+        $this->assertEquals('Client 1', $result[0]->name);
+        $this->assertEquals(['keys:read'], $result[0]->allowedScopes);
+        $this->assertEquals('Description 1', $result[0]->description);
+
+        $this->assertEquals('client-id-2', $result[1]->clientId);
+        $this->assertEquals('Client 2', $result[1]->name);
+        $this->assertEquals(['keys:read', 'hashes:read'], $result[1]->allowedScopes);
+        $this->assertEquals('Description 2', $result[1]->description);
+    }
+}

--- a/tests/Unit/Application/UseCases/Client/ProvisionClientUseCaseTest.php
+++ b/tests/Unit/Application/UseCases/Client/ProvisionClientUseCaseTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace JuniorFontenele\LaravelVaultServer\Tests\Unit\Application\UseCases\Client;
+
+use JuniorFontenele\LaravelVaultServer\Application\DTOs\Key\CreateKeyDTO;
+use JuniorFontenele\LaravelVaultServer\Application\DTOs\Key\CreateKeyResponseDTO;
+use JuniorFontenele\LaravelVaultServer\Application\UseCases\Client\ProvisionClientUseCase;
+use JuniorFontenele\LaravelVaultServer\Application\UseCases\Key\CreateKeyForClientUseCase;
+use JuniorFontenele\LaravelVaultServer\Domains\IAM\Client\Client;
+use JuniorFontenele\LaravelVaultServer\Domains\IAM\Client\Contracts\ClientRepositoryInterface;
+use JuniorFontenele\LaravelVaultServer\Domains\IAM\Client\Exceptions\ClientException;
+use JuniorFontenele\LaravelVaultServer\Domains\Shared\Contracts\UnitOfWorkInterface;
+use JuniorFontenele\LaravelVaultServer\Tests\TestCase;
+use Mockery;
+use Mockery\MockInterface;
+
+class ProvisionClientUseCaseTest extends TestCase
+{
+    private ClientRepositoryInterface|MockInterface $clientRepository;
+
+    private UnitOfWorkInterface|MockInterface $unitOfWork;
+
+    private ProvisionClientUseCase $useCase;
+
+    private CreateKeyForClientUseCase|MockInterface $createKeyForClientUseCase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->clientRepository = Mockery::mock(ClientRepositoryInterface::class);
+        $this->unitOfWork = Mockery::mock(UnitOfWorkInterface::class);
+        $this->createKeyForClientUseCase = Mockery::mock(CreateKeyForClientUseCase::class);
+
+        // We need to bind our mock to the container for app() calls
+        $this->app->instance(CreateKeyForClientUseCase::class, $this->createKeyForClientUseCase);
+
+        $this->useCase = new ProvisionClientUseCase($this->clientRepository, $this->unitOfWork);
+    }
+
+    public function testExecuteSuccess(): void
+    {
+        $client = Mockery::mock(Client::class);
+        $client->shouldReceive('isProvisioned')->andReturn(false);
+        $client->shouldReceive('clientId')->andReturn('test-client-id');
+        $client->shouldReceive('verifyProvisionToken')->with('token')->andReturn(true);
+        $client->shouldReceive('provision')->with('token')->andReturnNull();
+
+        $keyResponse = Mockery::mock(CreateKeyResponseDTO::class);
+
+        $this->clientRepository
+            ->shouldReceive('findClientByClientId')
+            ->once()
+            ->with('test-client-id')
+            ->andReturn($client);
+
+        $this->clientRepository
+            ->shouldReceive('save')
+            ->once()
+            ->with($client)
+            ->andReturnNull();
+
+        $this->createKeyForClientUseCase
+            ->shouldReceive('execute')
+            ->once()
+            ->with(Mockery::type(CreateKeyDTO::class))
+            ->andReturn($keyResponse);
+
+        $this->unitOfWork
+            ->shouldReceive('execute')
+            ->once()
+            ->andReturnUsing(function ($callback) {
+                return $callback();
+            });
+
+        $result = $this->useCase->execute('test-client-id', 'token');
+
+        $this->assertSame($keyResponse, $result);
+    }
+
+    public function testExecuteWithNonExistingClientThrowsException(): void
+    {
+        $this->clientRepository
+            ->shouldReceive('findClientByClientId')
+            ->once()
+            ->with('non-existing-id')
+            ->andReturnNull();
+
+        $this->expectException(ClientException::class);
+
+        $this->useCase->execute('non-existing-id', 'token');
+    }
+
+    public function testExecuteWithAlreadyProvisionedClientThrowsException(): void
+    {
+        $client = Mockery::mock(Client::class);
+        $client->shouldReceive('isProvisioned')->andReturn(true);
+        $client->shouldReceive('clientId')->andReturn('test-client-id');
+
+        $this->clientRepository
+            ->shouldReceive('findClientByClientId')
+            ->once()
+            ->with('test-client-id')
+            ->andReturn($client);
+
+        $this->expectException(ClientException::class);
+
+        $this->useCase->execute('test-client-id', 'token');
+    }
+
+    public function testExecuteWithInvalidTokenThrowsException(): void
+    {
+        $client = Mockery::mock(Client::class);
+        $client->shouldReceive('isProvisioned')->andReturn(false);
+        $client->shouldReceive('clientId')->andReturn('test-client-id');
+        $client->shouldReceive('verifyProvisionToken')->with('invalid-token')->andReturn(false);
+
+        $this->clientRepository
+            ->shouldReceive('findClientByClientId')
+            ->once()
+            ->with('test-client-id')
+            ->andReturn($client);
+
+        $this->expectException(ClientException::class);
+
+        $this->useCase->execute('test-client-id', 'invalid-token');
+    }
+}

--- a/tests/Unit/Application/UseCases/Client/ReprovisionClientUseCaseTest.php
+++ b/tests/Unit/Application/UseCases/Client/ReprovisionClientUseCaseTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace JuniorFontenele\LaravelVaultServer\Tests\Unit\Application\UseCases\Client;
+
+use JuniorFontenele\LaravelVaultServer\Application\DTOs\Client\CreateClientResponseDTO;
+use JuniorFontenele\LaravelVaultServer\Application\UseCases\Client\ReprovisionClientUseCase;
+use JuniorFontenele\LaravelVaultServer\Domains\IAM\Client\Client;
+use JuniorFontenele\LaravelVaultServer\Domains\IAM\Client\Contracts\ClientRepositoryInterface;
+use JuniorFontenele\LaravelVaultServer\Domains\IAM\Client\Exceptions\ClientException;
+use JuniorFontenele\LaravelVaultServer\Tests\TestCase;
+use Mockery;
+use Mockery\MockInterface;
+
+class ReprovisionClientUseCaseTest extends TestCase
+{
+    private ClientRepositoryInterface|MockInterface $clientRepository;
+
+    private ReprovisionClientUseCase $useCase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->clientRepository = Mockery::mock(ClientRepositoryInterface::class);
+        $this->useCase = new ReprovisionClientUseCase($this->clientRepository);
+    }
+
+    public function testExecuteSuccess(): void
+    {
+        $client = Mockery::mock(Client::class);
+        $client->shouldReceive('clientId')->andReturn('test-client-id');
+        $client->shouldReceive('name')->andReturn('Test Client');
+        $client->shouldReceive('scopes')->andReturn(['keys:read', 'hashes:read']);
+        $client->shouldReceive('provisionToken')->andReturn('new-token');
+        $client->shouldReceive('description')->andReturn('Test description');
+        $client->shouldReceive('reprovision')->once()->andReturnNull();
+
+        $this->clientRepository
+            ->shouldReceive('findClientByClientId')
+            ->once()
+            ->with('test-client-id')
+            ->andReturn($client);
+
+        $this->clientRepository
+            ->shouldReceive('save')
+            ->once()
+            ->with($client)
+            ->andReturnNull();
+
+        $response = $this->useCase->execute('test-client-id');
+
+        $this->assertInstanceOf(CreateClientResponseDTO::class, $response);
+        $this->assertEquals('test-client-id', $response->clientId);
+        $this->assertEquals('Test Client', $response->name);
+        $this->assertEquals(['keys:read', 'hashes:read'], $response->allowedScopes);
+        $this->assertEquals('new-token', $response->provisionToken);
+        $this->assertEquals('Test description', $response->description);
+    }
+
+    public function testExecuteWithNonExistingClientThrowsException(): void
+    {
+        $this->clientRepository
+            ->shouldReceive('findClientByClientId')
+            ->once()
+            ->with('non-existing-id')
+            ->andReturnNull();
+
+        $this->expectException(ClientException::class);
+
+        $this->useCase->execute('non-existing-id');
+    }
+}

--- a/tests/Unit/Application/UseCases/Key/CreateKeyForClientUseCaseTest.php
+++ b/tests/Unit/Application/UseCases/Key/CreateKeyForClientUseCaseTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace JuniorFontenele\LaravelVaultServer\Tests\Unit\Application\UseCases\Key;
+
+use DateTimeImmutable;
+use JuniorFontenele\LaravelVaultServer\Application\DTOs\Key\CreateKeyDTO;
+use JuniorFontenele\LaravelVaultServer\Application\DTOs\Key\CreateKeyResponseDTO;
+use JuniorFontenele\LaravelVaultServer\Application\DTOs\Key\KeyResponseDTO;
+use JuniorFontenele\LaravelVaultServer\Application\UseCases\Key\CreateKeyForClientUseCase;
+use JuniorFontenele\LaravelVaultServer\Application\UseCases\Key\FindAllKeysForClientUseCase;
+use JuniorFontenele\LaravelVaultServer\Application\UseCases\Key\RevokeKeyUseCase;
+use JuniorFontenele\LaravelVaultServer\Domains\IAM\Client\ClientId;
+use JuniorFontenele\LaravelVaultServer\Domains\Shared\Contracts\UnitOfWorkInterface;
+use JuniorFontenele\LaravelVaultServer\Domains\Vault\Key\Contracts\KeyRepositoryInterface;
+use JuniorFontenele\LaravelVaultServer\Domains\Vault\Key\KeyId;
+use JuniorFontenele\LaravelVaultServer\Tests\TestCase;
+use Mockery;
+use Mockery\MockInterface;
+
+class CreateKeyForClientUseCaseTest extends TestCase
+{
+    private KeyRepositoryInterface|MockInterface $keyRepository;
+
+    private UnitOfWorkInterface|MockInterface $unitOfWork;
+
+    private FindAllKeysForClientUseCase|MockInterface $findAllKeysForClientUseCase;
+
+    private RevokeKeyUseCase|MockInterface $revokeKeyUseCase;
+
+    private CreateKeyForClientUseCase $useCase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->keyRepository = Mockery::mock(KeyRepositoryInterface::class);
+        $this->unitOfWork = Mockery::mock(UnitOfWorkInterface::class);
+        $this->findAllKeysForClientUseCase = Mockery::mock(FindAllKeysForClientUseCase::class);
+        $this->revokeKeyUseCase = Mockery::mock(RevokeKeyUseCase::class);
+
+        $this->useCase = new CreateKeyForClientUseCase(
+            $this->keyRepository,
+            $this->unitOfWork,
+            $this->findAllKeysForClientUseCase,
+            $this->revokeKeyUseCase
+        );
+    }
+
+    public function testExecuteSuccess(): void
+    {
+        $clientId = (new ClientId())->value();
+        $keyDto = new CreateKeyDTO(
+            clientId: $clientId,
+            keySize: 2048,
+            expiresIn: 365
+        );
+
+        // Create KeyResponseDTO objects with the correct keyId values
+        $keyId1 = (new KeyId())->value();
+        $keyId2 = (new KeyId())->value();
+
+        $existingKey1 = new KeyResponseDTO(
+            keyId: $keyId1,
+            clientId: $clientId,
+            publicKey: 'public-key-1',
+            version: 1,
+            validFrom: new DateTimeImmutable(),
+            validUntil: new DateTimeImmutable('+1 year'),
+            isRevoked: false,
+            revokedAt: null
+        );
+
+        $existingKey2 = new KeyResponseDTO(
+            keyId: $keyId2,
+            clientId: $clientId,
+            publicKey: 'public-key-2',
+            version: 2,
+            validFrom: new DateTimeImmutable(),
+            validUntil: new DateTimeImmutable('+1 year'),
+            isRevoked: false,
+            revokedAt: null
+        );
+
+        $this->findAllKeysForClientUseCase
+            ->shouldReceive('execute')
+            ->once()
+            ->with($clientId)
+            ->andReturn([$existingKey1, $existingKey2]);
+
+        // Use the same keyId values that match the KeyResponseDTO objects
+        $this->revokeKeyUseCase
+            ->shouldReceive('execute')
+            ->once()
+            ->with($keyId1)
+            ->andReturnNull();
+
+        $this->revokeKeyUseCase
+            ->shouldReceive('execute')
+            ->once()
+            ->with($keyId2)
+            ->andReturnNull();
+
+        $this->keyRepository
+            ->shouldReceive('maxVersion')
+            ->once()
+            ->with($clientId)
+            ->andReturn(2);
+
+        $this->keyRepository
+            ->shouldReceive('save')
+            ->once()
+            ->andReturnNull();
+
+        $this->unitOfWork
+            ->shouldReceive('execute')
+            ->once()
+            ->andReturnUsing(function ($callback) {
+                return $callback();
+            });
+
+        $result = $this->useCase->execute($keyDto);
+
+        $this->assertInstanceOf(CreateKeyResponseDTO::class, $result);
+        $this->assertNotEmpty($result->keyId);
+        $this->assertEquals($clientId, $result->clientId);
+        $this->assertNotEmpty($result->publicKey);
+        $this->assertNotEmpty($result->privateKey);
+        $this->assertEquals(3, $result->version); // Should be maxVersion + 1
+        $this->assertInstanceOf(DateTimeImmutable::class, $result->validFrom);
+        $this->assertInstanceOf(DateTimeImmutable::class, $result->validUntil);
+    }
+}

--- a/tests/Unit/Application/UseCases/Key/FindActiveKeyForClientUseCaseTest.php
+++ b/tests/Unit/Application/UseCases/Key/FindActiveKeyForClientUseCaseTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace JuniorFontenele\LaravelVaultServer\Tests\Unit\Application\UseCases\Key;
+
+use DateTimeImmutable;
+use JuniorFontenele\LaravelVaultServer\Application\DTOs\Key\KeyResponseDTO;
+use JuniorFontenele\LaravelVaultServer\Application\UseCases\Key\FindActiveKeyForClientUseCase;
+use JuniorFontenele\LaravelVaultServer\Domains\Vault\Key\Contracts\KeyRepositoryInterface;
+use JuniorFontenele\LaravelVaultServer\Domains\Vault\Key\Key;
+use JuniorFontenele\LaravelVaultServer\Domains\Vault\Key\KeyId;
+use JuniorFontenele\LaravelVaultServer\Domains\Vault\Key\ValueObjects\ClientId;
+use JuniorFontenele\LaravelVaultServer\Domains\Vault\Key\ValueObjects\PublicKey;
+use JuniorFontenele\LaravelVaultServer\Tests\TestCase;
+use Mockery;
+use Mockery\MockInterface;
+
+class FindActiveKeyForClientUseCaseTest extends TestCase
+{
+    private KeyRepositoryInterface|MockInterface $keyRepository;
+
+    private FindActiveKeyForClientUseCase $useCase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->keyRepository = Mockery::mock(KeyRepositoryInterface::class);
+        $this->useCase = new FindActiveKeyForClientUseCase($this->keyRepository);
+    }
+
+    public function testExecuteWithExistingKey(): void
+    {
+        $clientId = 'test-client-id';
+        $keyId = 'test-key-id';
+        $publicKeyValue = 'public-key-content';
+        $validFrom = new DateTimeImmutable();
+        $validUntil = new DateTimeImmutable('+1 year');
+
+        $keyIdMock = Mockery::mock(KeyId::class);
+        $keyIdMock->shouldReceive('value')->andReturn($keyId);
+
+        $clientIdMock = Mockery::mock(ClientId::class);
+        $clientIdMock->shouldReceive('value')->andReturn($clientId);
+
+        $publicKeyMock = Mockery::mock(PublicKey::class);
+        $publicKeyMock->shouldReceive('value')->andReturn($publicKeyValue);
+
+        $key = Mockery::mock(Key::class, [
+            $keyIdMock,
+            $clientIdMock,
+            $publicKeyMock,
+            1,
+            $validFrom,
+            $validUntil,
+            false,
+            null,
+        ]);
+
+        $key->shouldReceive('keyId')->andReturn($keyId);
+        $key->shouldReceive('clientId')->andReturn($clientId);
+        $key->shouldReceive('publicKey')->andReturn($publicKeyValue);
+        $key->shouldReceive('version')->andReturn(1);
+        $key->shouldReceive('validFrom')->andReturn($validFrom);
+        $key->shouldReceive('validUntil')->andReturn($validUntil);
+        $key->shouldReceive('isRevoked')->andReturn(false);
+        $key->shouldReceive('revokedAt')->andReturn(null);
+
+        $this->keyRepository
+            ->shouldReceive('findActiveKeyByClientId')
+            ->once()
+            ->with($clientId)
+            ->andReturn($key);
+
+        $result = $this->useCase->execute($clientId);
+
+        $this->assertInstanceOf(KeyResponseDTO::class, $result);
+        $this->assertEquals($keyId, $result->keyId);
+        $this->assertEquals($clientId, $result->clientId);
+        $this->assertEquals($publicKeyValue, $result->publicKey);
+        $this->assertEquals(1, $result->version);
+        $this->assertSame($validFrom, $result->validFrom);
+        $this->assertSame($validUntil, $result->validUntil);
+        $this->assertFalse($result->isRevoked);
+        $this->assertNull($result->revokedAt);
+    }
+
+    public function testExecuteWithNoKey(): void
+    {
+        $clientId = 'test-client-id';
+
+        $this->keyRepository
+            ->shouldReceive('findActiveKeyByClientId')
+            ->once()
+            ->with($clientId)
+            ->andReturnNull();
+
+        $result = $this->useCase->execute($clientId);
+
+        $this->assertNull($result);
+    }
+}

--- a/tests/Unit/Application/UseCases/Key/RotateKeyUseCaseTest.php
+++ b/tests/Unit/Application/UseCases/Key/RotateKeyUseCaseTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace JuniorFontenele\LaravelVaultServer\Tests\Unit\Application\UseCases\Key;
+
+use DateTimeImmutable;
+use JuniorFontenele\LaravelVaultServer\Application\DTOs\Key\CreateKeyResponseDTO;
+use JuniorFontenele\LaravelVaultServer\Application\UseCases\Key\RotateKeyUseCase;
+use JuniorFontenele\LaravelVaultServer\Domains\IAM\Client\ClientId;
+use JuniorFontenele\LaravelVaultServer\Domains\Shared\Contracts\UnitOfWorkInterface;
+use JuniorFontenele\LaravelVaultServer\Domains\Vault\Key\Contracts\KeyRepositoryInterface;
+use JuniorFontenele\LaravelVaultServer\Domains\Vault\Key\Exceptions\PublicKeyException;
+use JuniorFontenele\LaravelVaultServer\Domains\Vault\Key\Key;
+use JuniorFontenele\LaravelVaultServer\Domains\Vault\Key\KeyId;
+use JuniorFontenele\LaravelVaultServer\Tests\TestCase;
+use Mockery;
+use Mockery\MockInterface;
+
+class RotateKeyUseCaseTest extends TestCase
+{
+    private KeyRepositoryInterface|MockInterface $keyRepository;
+
+    private UnitOfWorkInterface|MockInterface $unitOfWork;
+
+    private RotateKeyUseCase $useCase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->keyRepository = Mockery::mock(KeyRepositoryInterface::class);
+        $this->unitOfWork = Mockery::mock(UnitOfWorkInterface::class);
+
+        $this->useCase = new RotateKeyUseCase($this->keyRepository, $this->unitOfWork);
+    }
+
+    public function testExecuteSuccess(): void
+    {
+        $keyId = (new KeyId())->value();
+        $clientId = (new ClientId())->value();
+
+        $key = Mockery::mock(Key::class);
+        $key->shouldReceive('clientId')->andReturn($clientId);
+
+        $this->keyRepository
+            ->shouldReceive('findKeyByKeyId')
+            ->once()
+            ->with($keyId)
+            ->andReturn($key);
+
+        $nonRevokedKey1 = Mockery::mock(Key::class);
+        $nonRevokedKey1->shouldReceive('revoke')->once()->andReturnNull();
+
+        $nonRevokedKey2 = Mockery::mock(Key::class);
+        $nonRevokedKey2->shouldReceive('revoke')->once()->andReturnNull();
+
+        $this->keyRepository
+            ->shouldReceive('findAllNonRevokedKeysByClientId')
+            ->once()
+            ->with($clientId)
+            ->andReturn([$nonRevokedKey1, $nonRevokedKey2]);
+
+        $this->keyRepository
+            ->shouldReceive('save')
+            ->times(3) // 2 revoked keys + 1 new key
+            ->andReturnNull();
+
+        $this->keyRepository
+            ->shouldReceive('maxVersion')
+            ->once()
+            ->with($clientId)
+            ->andReturn(2);
+
+        $this->unitOfWork
+            ->shouldReceive('execute')
+            ->once()
+            ->andReturnUsing(function ($callback) {
+                return $callback();
+            });
+
+        $result = $this->useCase->execute($keyId);
+
+        $this->assertInstanceOf(CreateKeyResponseDTO::class, $result);
+        $this->assertNotEmpty($result->keyId);
+        $this->assertEquals($clientId, $result->clientId);
+        $this->assertNotEmpty($result->publicKey);
+        $this->assertNotEmpty($result->privateKey);
+        $this->assertEquals(3, $result->version); // maxVersion + 1
+        $this->assertInstanceOf(DateTimeImmutable::class, $result->validFrom);
+        $this->assertInstanceOf(DateTimeImmutable::class, $result->validUntil);
+    }
+
+    public function testExecuteWithNonExistingKeyThrowsException(): void
+    {
+        $keyId = 'non-existing-key-id';
+
+        $this->keyRepository
+            ->shouldReceive('findKeyByKeyId')
+            ->once()
+            ->with($keyId)
+            ->andReturnNull();
+
+        $this->expectException(PublicKeyException::class);
+
+        $this->useCase->execute($keyId);
+    }
+}

--- a/tests/Unit/Domains/IAM/Client/ClientIdTest.php
+++ b/tests/Unit/Domains/IAM/Client/ClientIdTest.php
@@ -16,14 +16,14 @@ class ClientIdTest extends TestCase
         $uuid = Uuid::uuid4()->toString();
         $clientId = new ClientId($uuid);
 
-        $this->assertEquals($uuid, $clientId->value);
+        $this->assertEquals($uuid, $clientId->value());
     }
 
     public function testCreateClientIdWithoutUuidGeneratesOne(): void
     {
         $clientId = new ClientId();
 
-        $this->assertTrue(Uuid::isValid($clientId->value));
+        $this->assertTrue(Uuid::isValid($clientId->value()));
     }
 
     public function testCreateClientIdWithInvalidUuidThrowsException(): void

--- a/tests/Unit/Domains/IAM/Client/ClientIdTest.php
+++ b/tests/Unit/Domains/IAM/Client/ClientIdTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace JuniorFontenele\LaravelVaultServer\Tests\Unit\Domains\IAM\Client;
+
+use JuniorFontenele\LaravelVaultServer\Domains\IAM\Client\ClientId;
+use JuniorFontenele\LaravelVaultServer\Domains\IAM\Client\Exceptions\ClientIdException;
+use JuniorFontenele\LaravelVaultServer\Tests\TestCase;
+use Ramsey\Uuid\Uuid;
+
+class ClientIdTest extends TestCase
+{
+    public function testCreateClientIdWithValidUuid(): void
+    {
+        $uuid = Uuid::uuid4()->toString();
+        $clientId = new ClientId($uuid);
+
+        $this->assertEquals($uuid, $clientId->value);
+    }
+
+    public function testCreateClientIdWithoutUuidGeneratesOne(): void
+    {
+        $clientId = new ClientId();
+
+        $this->assertTrue(Uuid::isValid($clientId->value));
+    }
+
+    public function testCreateClientIdWithInvalidUuidThrowsException(): void
+    {
+        $this->expectException(ClientIdException::class);
+
+        new ClientId('not-a-valid-uuid');
+    }
+}

--- a/tests/Unit/Domains/IAM/Client/ClientTest.php
+++ b/tests/Unit/Domains/IAM/Client/ClientTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace JuniorFontenele\LaravelVaultServer\Tests\Unit\Domains\IAM\Client;
+
+use DateTimeImmutable;
+use JuniorFontenele\LaravelVaultServer\Domains\IAM\Client\Client;
+use JuniorFontenele\LaravelVaultServer\Domains\IAM\Client\ClientId;
+use JuniorFontenele\LaravelVaultServer\Domains\IAM\Client\Enums\Scope;
+use JuniorFontenele\LaravelVaultServer\Domains\IAM\Client\Exceptions\ClientException;
+use JuniorFontenele\LaravelVaultServer\Domains\IAM\Client\ValueObjects\AllowedScopes;
+use JuniorFontenele\LaravelVaultServer\Domains\IAM\Client\ValueObjects\ProvisionToken;
+use JuniorFontenele\LaravelVaultServer\Tests\TestCase;
+
+class ClientTest extends TestCase
+{
+    private Client $client;
+
+    private ClientId $clientId;
+
+    private AllowedScopes $allowedScopes;
+
+    private ProvisionToken $provisionToken;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->clientId = new ClientId();
+        $this->allowedScopes = new AllowedScopes([Scope::KEYS_READ, Scope::HASHES_READ]);
+        $this->provisionToken = new ProvisionToken();
+
+        $this->client = new Client(
+            $this->clientId,
+            'Test Client',
+            $this->allowedScopes,
+            true,
+            'Test Description',
+            $this->provisionToken
+        );
+    }
+
+    public function testClientCreation(): void
+    {
+        $this->assertEquals($this->clientId->value, $this->client->clientId());
+        $this->assertEquals('Test Client', $this->client->name());
+        $this->assertEquals('Test Description', $this->client->description());
+        $this->assertCount(2, $this->client->scopes());
+        $this->assertTrue($this->client->isActive());
+        $this->assertFalse($this->client->isProvisioned());
+        $this->assertTrue($this->client->isNotProvisioned());
+        $this->assertNull($this->client->provisionedAt());
+        $this->assertEquals($this->provisionToken->plainValue(), $this->client->provisionToken());
+    }
+
+    public function testProvisionClient(): void
+    {
+        $tokenValue = $this->provisionToken->plainValue();
+        $this->client->provision($tokenValue);
+
+        $this->assertTrue($this->client->isProvisioned());
+        $this->assertFalse($this->client->isNotProvisioned());
+        $this->assertNull($this->client->provisionToken());
+        $this->assertInstanceOf(DateTimeImmutable::class, $this->client->provisionedAt());
+    }
+
+    public function testProvisionClientWithInvalidTokenThrowsException(): void
+    {
+        $this->expectException(ClientException::class);
+
+        $this->client->provision('invalid-token');
+    }
+
+    public function testProvisionClientThatIsAlreadyProvisionedThrowsException(): void
+    {
+        $this->client->provision($this->provisionToken->plainValue());
+
+        $this->expectException(ClientException::class);
+
+        $this->client->provision($this->provisionToken->plainValue());
+    }
+
+    public function testReprovisionClient(): void
+    {
+        $this->client->provision($this->provisionToken->plainValue());
+        $this->assertTrue($this->client->isProvisioned());
+
+        $this->client->reprovision();
+
+        $this->assertFalse($this->client->isProvisioned());
+        $this->assertNotNull($this->client->provisionToken());
+    }
+
+    public function testDeactivateClient(): void
+    {
+        $this->assertTrue($this->client->isActive());
+
+        $this->client->deactivate();
+
+        $this->assertFalse($this->client->isActive());
+    }
+
+    public function testActivateClient(): void
+    {
+        $this->client->deactivate();
+        $this->assertFalse($this->client->isActive());
+
+        $this->client->activate();
+
+        $this->assertTrue($this->client->isActive());
+    }
+}

--- a/tests/Unit/Domains/IAM/Client/ClientTest.php
+++ b/tests/Unit/Domains/IAM/Client/ClientTest.php
@@ -43,7 +43,7 @@ class ClientTest extends TestCase
 
     public function testClientCreation(): void
     {
-        $this->assertEquals($this->clientId->value, $this->client->clientId());
+        $this->assertEquals($this->clientId->value(), $this->client->clientId());
         $this->assertEquals('Test Client', $this->client->name());
         $this->assertEquals('Test Description', $this->client->description());
         $this->assertCount(2, $this->client->scopes());

--- a/tests/Unit/Domains/IAM/Client/Enums/ScopeTest.php
+++ b/tests/Unit/Domains/IAM/Client/Enums/ScopeTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace JuniorFontenele\LaravelVaultServer\Tests\Unit\Domains\IAM\Client\Enums;
+
+use JuniorFontenele\LaravelVaultServer\Domains\IAM\Client\Enums\Scope;
+use JuniorFontenele\LaravelVaultServer\Domains\IAM\Client\Exceptions\InvalidScopeException;
+use JuniorFontenele\LaravelVaultServer\Tests\TestCase;
+
+class ScopeTest extends TestCase
+{
+    public function testGetLabel(): void
+    {
+        $this->assertEquals('Read keys', Scope::KEYS_READ->getLabel());
+        $this->assertEquals('Rotate keys', Scope::KEYS_ROTATE->getLabel());
+        $this->assertEquals('Delete keys', Scope::KEYS_DELETE->getLabel());
+        $this->assertEquals('Read hashes', Scope::HASHES_READ->getLabel());
+        $this->assertEquals('Create hashes', Scope::HASHES_CREATE->getLabel());
+        $this->assertEquals('Delete hashes', Scope::HASHES_DELETE->getLabel());
+    }
+
+    public function testToArray(): void
+    {
+        $scopesArray = Scope::toArray();
+
+        $this->assertCount(6, $scopesArray);
+        $this->assertEquals('Read keys', $scopesArray['keys:read']);
+        $this->assertEquals('Rotate keys', $scopesArray['keys:rotate']);
+        $this->assertEquals('Delete keys', $scopesArray['keys:delete']);
+        $this->assertEquals('Read hashes', $scopesArray['hashes:read']);
+        $this->assertEquals('Create hashes', $scopesArray['hashes:create']);
+        $this->assertEquals('Delete hashes', $scopesArray['hashes:delete']);
+    }
+
+    public function testFromString(): void
+    {
+        $this->assertEquals(Scope::KEYS_READ, Scope::fromString('keys:read'));
+        $this->assertEquals(Scope::KEYS_ROTATE, Scope::fromString('keys:rotate'));
+    }
+
+    public function testFromStringWithInvalidScopeThrowsException(): void
+    {
+        $this->expectException(InvalidScopeException::class);
+
+        Scope::fromString('invalid:scope');
+    }
+}

--- a/tests/Unit/Domains/IAM/Client/Exceptions/ClientExceptionTest.php
+++ b/tests/Unit/Domains/IAM/Client/Exceptions/ClientExceptionTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace JuniorFontenele\LaravelVaultServer\Tests\Unit\Domains\IAM\Client\Exceptions;
+
+use JuniorFontenele\LaravelVaultServer\Domains\IAM\Client\Exceptions\ClientException;
+use JuniorFontenele\LaravelVaultServer\Tests\TestCase;
+
+class ClientExceptionTest extends TestCase
+{
+    public function testAlreadyProvisioned(): void
+    {
+        $exception = ClientException::alreadyProvisioned('test-client-id');
+
+        $this->assertEquals('Cliente test-client-id já foi provisionado', $exception->getMessage());
+        $this->assertEquals('Cliente :id já foi provisionado', $exception->translationKey());
+        $this->assertEquals(['id' => 'test-client-id'], $exception->translationParameters());
+    }
+
+    public function testInvalidProvisionToken(): void
+    {
+        $exception = ClientException::invalidProvisionToken('test-client-id');
+
+        $this->assertEquals('Token de provisionamento inválido para o cliente test-client-id', $exception->getMessage());
+        $this->assertEquals('Token de provisionamento inválido para o cliente :id', $exception->translationKey());
+        $this->assertEquals(['id' => 'test-client-id'], $exception->translationParameters());
+    }
+
+    public function testNotFound(): void
+    {
+        $exception = ClientException::notFound('test-client-id');
+
+        $this->assertEquals('Cliente test-client-id não encontrado', $exception->getMessage());
+        $this->assertEquals('Cliente :id não encontrado', $exception->translationKey());
+        $this->assertEquals(['id' => 'test-client-id'], $exception->translationParameters());
+    }
+}

--- a/tests/Unit/Domains/IAM/Client/ValueObjects/AllowedScopesTest.php
+++ b/tests/Unit/Domains/IAM/Client/ValueObjects/AllowedScopesTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace JuniorFontenele\LaravelVaultServer\Tests\Unit\Domains\IAM\Client\ValueObjects;
+
+use JuniorFontenele\LaravelVaultServer\Domains\IAM\Client\Enums\Scope;
+use JuniorFontenele\LaravelVaultServer\Domains\IAM\Client\Exceptions\InvalidScopeException;
+use JuniorFontenele\LaravelVaultServer\Domains\IAM\Client\ValueObjects\AllowedScopes;
+use JuniorFontenele\LaravelVaultServer\Tests\TestCase;
+
+class AllowedScopesTest extends TestCase
+{
+    public function testCreateAllowedScopes(): void
+    {
+        $scopes = new AllowedScopes([Scope::KEYS_READ, Scope::HASHES_READ]);
+
+        $this->assertCount(2, $scopes->all());
+        $this->assertEquals([Scope::KEYS_READ, Scope::HASHES_READ], $scopes->all());
+    }
+
+    public function testCreateAllowedScopesWithInvalidTypeThrowsException(): void
+    {
+        $this->expectException(InvalidScopeException::class);
+
+        new AllowedScopes(['invalid-scope']);
+    }
+
+    public function testHasScope(): void
+    {
+        $scopes = new AllowedScopes([Scope::KEYS_READ, Scope::HASHES_READ]);
+
+        $this->assertTrue($scopes->has(Scope::KEYS_READ));
+        $this->assertTrue($scopes->has('keys:read'));
+        $this->assertFalse($scopes->has(Scope::KEYS_DELETE));
+    }
+
+    public function testFromStringArray(): void
+    {
+        $scopes = AllowedScopes::fromStringArray(['keys:read', 'hashes:read']);
+
+        $this->assertCount(2, $scopes->all());
+        $this->assertTrue($scopes->has(Scope::KEYS_READ));
+        $this->assertTrue($scopes->has(Scope::HASHES_READ));
+    }
+
+    public function testFromStringArrayWithInvalidScopeThrowsException(): void
+    {
+        $this->expectException(InvalidScopeException::class);
+
+        AllowedScopes::fromStringArray(['invalid:scope']);
+    }
+
+    public function testToArray(): void
+    {
+        $scopes = new AllowedScopes([Scope::KEYS_READ, Scope::HASHES_READ]);
+
+        $this->assertEquals(['keys:read', 'hashes:read'], $scopes->toArray());
+    }
+
+    public function testToString(): void
+    {
+        $scopes = new AllowedScopes([Scope::KEYS_READ, Scope::HASHES_READ]);
+
+        $this->assertEquals('keys:read hashes:read', (string) $scopes);
+    }
+
+    public function testSeparator(): void
+    {
+        $scopes = new AllowedScopes([Scope::KEYS_READ, Scope::HASHES_READ]);
+        $scopes->separator(',');
+
+        $this->assertEquals('keys:read,hashes:read', (string) $scopes);
+    }
+}

--- a/tests/Unit/Domains/IAM/Client/ValueObjects/ProvisionTokenTest.php
+++ b/tests/Unit/Domains/IAM/Client/ValueObjects/ProvisionTokenTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace JuniorFontenele\LaravelVaultServer\Tests\Unit\Domains\IAM\Client\ValueObjects;
+
+use JuniorFontenele\LaravelVaultServer\Domains\IAM\Client\ValueObjects\ProvisionToken;
+use JuniorFontenele\LaravelVaultServer\Tests\TestCase;
+
+class ProvisionTokenTest extends TestCase
+{
+    public function testCreateProvisionToken(): void
+    {
+        $token = new ProvisionToken();
+
+        $this->assertNotEmpty($token->plainValue());
+    }
+
+    public function testVerifyToken(): void
+    {
+        $token = new ProvisionToken();
+        $plainValue = $token->plainValue();
+
+        $this->assertTrue($token->verify($plainValue));
+        $this->assertFalse($token->verify('invalid-token'));
+    }
+
+    public function testVerifyTokenWithTokenObject(): void
+    {
+        $token1 = new ProvisionToken();
+        $token2 = new ProvisionToken();
+
+        $this->assertTrue($token1->verify($token1->plainValue()));
+        $this->assertFalse($token1->verify($token2->plainValue()));
+    }
+}

--- a/tests/Unit/Domains/IAM/Client/ValueObjects/ProvisionTokenTest.php
+++ b/tests/Unit/Domains/IAM/Client/ValueObjects/ProvisionTokenTest.php
@@ -30,7 +30,7 @@ class ProvisionTokenTest extends TestCase
         $token1 = new ProvisionToken();
         $token2 = new ProvisionToken();
 
-        $this->assertTrue($token1->verify($token1->plainValue()));
-        $this->assertFalse($token1->verify($token2->plainValue()));
+        $this->assertTrue($token1->verify($token1));
+        $this->assertFalse($token1->verify($token2));
     }
 }

--- a/tests/Unit/Domains/Shared/Traits/HasTranslationsTest.php
+++ b/tests/Unit/Domains/Shared/Traits/HasTranslationsTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace JuniorFontenele\LaravelVaultServer\Tests\Unit\Domains\Shared\Traits;
+
+use JuniorFontenele\LaravelVaultServer\Domains\Shared\Contracts\Translatable;
+use JuniorFontenele\LaravelVaultServer\Domains\Shared\Traits\HasTranslations;
+use JuniorFontenele\LaravelVaultServer\Tests\TestCase;
+
+class HasTranslationsTest extends TestCase
+{
+    public function testWithTranslation(): void
+    {
+        $exception = MockException::withTranslation('Hello :name', ['name' => 'World']);
+
+        $this->assertEquals('Hello World', $exception->getMessage());
+        $this->assertEquals('Hello :name', $exception->translationKey());
+        $this->assertEquals(['name' => 'World'], $exception->translationParameters());
+    }
+
+    public function testWithTranslationWithNumericKeys(): void
+    {
+        $exception = MockException::withTranslation('Hello :value', [0 => 'World']);
+
+        $this->assertEquals('Hello World', $exception->getMessage());
+    }
+
+    public function testWithTranslationWithNoParameters(): void
+    {
+        $exception = MockException::withTranslation('Hello World');
+
+        $this->assertEquals('Hello World', $exception->getMessage());
+        $this->assertEquals('Hello World', $exception->translationKey());
+        $this->assertEquals([], $exception->translationParameters());
+    }
+}
+
+class MockException extends \Exception implements Translatable
+{
+    use HasTranslations;
+}

--- a/tests/Unit/Domains/Vault/Hash/HashIdTest.php
+++ b/tests/Unit/Domains/Vault/Hash/HashIdTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace JuniorFontenele\LaravelVaultServer\Tests\Unit\Domains\Vault\Hash;
+
+use JuniorFontenele\LaravelVaultServer\Domains\Vault\Hash\Exceptions\HashIdException;
+use JuniorFontenele\LaravelVaultServer\Domains\Vault\Hash\HashId;
+use JuniorFontenele\LaravelVaultServer\Tests\TestCase;
+use Ramsey\Uuid\Uuid;
+
+class HashIdTest extends TestCase
+{
+    public function testCreateHashIdWithValidUuid(): void
+    {
+        $uuid = Uuid::uuid4()->toString();
+        $hashId = new HashId($uuid);
+
+        $this->assertEquals($uuid, $hashId->value());
+        $this->assertEquals($uuid, (string) $hashId);
+    }
+
+    public function testCreateHashIdWithoutUuidGeneratesOne(): void
+    {
+        $hashId = new HashId();
+
+        $this->assertTrue(Uuid::isValid($hashId->value()));
+    }
+
+    public function testCreateHashIdWithInvalidUuidThrowsException(): void
+    {
+        $this->expectException(HashIdException::class);
+
+        new HashId('not-a-valid-uuid');
+    }
+}

--- a/tests/Unit/Domains/Vault/Hash/HashTest.php
+++ b/tests/Unit/Domains/Vault/Hash/HashTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace JuniorFontenele\LaravelVaultServer\Tests\Unit\Domains\Vault\Hash;
+
+use DateTimeImmutable;
+use JuniorFontenele\LaravelVaultServer\Domains\Vault\Hash\Hash;
+use JuniorFontenele\LaravelVaultServer\Domains\Vault\Hash\HashId;
+use JuniorFontenele\LaravelVaultServer\Domains\Vault\Hash\ValueObjects\UserId;
+use JuniorFontenele\LaravelVaultServer\Tests\TestCase;
+use Ramsey\Uuid\Uuid;
+
+class HashTest extends TestCase
+{
+    private Hash $hash;
+
+    private HashId $hashId;
+
+    private UserId $userId;
+
+    private string $hashValue;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->hashId = new HashId(Uuid::uuid4()->toString());
+        $this->userId = new UserId(Uuid::uuid4()->toString());
+        $this->hashValue = 'hashed-value-123456';
+
+        $this->hash = new Hash(
+            $this->hashId,
+            $this->userId,
+            $this->hashValue,
+            1,
+            false,
+            null
+        );
+    }
+
+    public function testHashCreation(): void
+    {
+        $this->assertEquals($this->hashId->value(), $this->hash->hashId());
+        $this->assertEquals($this->userId->value(), $this->hash->userId());
+        $this->assertEquals($this->hashValue, $this->hash->hash());
+        $this->assertEquals(1, $this->hash->version());
+        $this->assertFalse($this->hash->isRevoked());
+        $this->assertNull($this->hash->revokedAt());
+    }
+
+    public function testHashCreationWithRevoked(): void
+    {
+        $revokedAt = new DateTimeImmutable('2023-01-01');
+
+        $revokedHash = new Hash(
+            $this->hashId,
+            $this->userId,
+            $this->hashValue,
+            1,
+            true,
+            $revokedAt
+        );
+
+        $this->assertEquals($this->hashId->value(), $revokedHash->hashId());
+        $this->assertEquals($this->userId->value(), $revokedHash->userId());
+        $this->assertEquals($this->hashValue, $revokedHash->hash());
+        $this->assertEquals(1, $revokedHash->version());
+        $this->assertTrue($revokedHash->isRevoked());
+        $this->assertEquals($revokedAt, $revokedHash->revokedAt());
+    }
+}

--- a/tests/Unit/Domains/Vault/Hash/ValueObjects/UserIdTest.php
+++ b/tests/Unit/Domains/Vault/Hash/ValueObjects/UserIdTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace JuniorFontenele\LaravelVaultServer\Tests\Unit\Domains\Vault\Hash\ValueObjects;
+
+use JuniorFontenele\LaravelVaultServer\Domains\Vault\Hash\Exceptions\UserIdException;
+use JuniorFontenele\LaravelVaultServer\Domains\Vault\Hash\ValueObjects\UserId;
+use JuniorFontenele\LaravelVaultServer\Tests\TestCase;
+use Ramsey\Uuid\Uuid;
+
+class UserIdTest extends TestCase
+{
+    public function testCreateUserIdWithValidUuid(): void
+    {
+        $uuid = Uuid::uuid4()->toString();
+        $userId = new UserId($uuid);
+
+        $this->assertEquals($uuid, $userId->value());
+        $this->assertEquals($uuid, (string) $userId);
+    }
+
+    public function testCreateUserIdWithInvalidUuidThrowsException(): void
+    {
+        $this->expectException(UserIdException::class);
+
+        new UserId('not-a-valid-uuid');
+    }
+}

--- a/tests/Unit/Domains/Vault/Key/KeyTest.php
+++ b/tests/Unit/Domains/Vault/Key/KeyTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace JuniorFontenele\LaravelVaultServer\Tests\Unit\Domains\Vault\Key;
+
+use DateTimeImmutable;
+use JuniorFontenele\LaravelVaultServer\Domains\Vault\Key\Key;
+use JuniorFontenele\LaravelVaultServer\Domains\Vault\Key\KeyId;
+use JuniorFontenele\LaravelVaultServer\Domains\Vault\Key\ValueObjects\ClientId;
+use JuniorFontenele\LaravelVaultServer\Domains\Vault\Key\ValueObjects\PublicKey;
+use JuniorFontenele\LaravelVaultServer\Tests\TestCase;
+use Ramsey\Uuid\Uuid;
+
+class KeyTest extends TestCase
+{
+    private Key $key;
+
+    private KeyId $keyId;
+
+    private ClientId $clientId;
+
+    private PublicKey $publicKey;
+
+    private DateTimeImmutable $validFrom;
+
+    private DateTimeImmutable $validUntil;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->keyId = $this->createMock(KeyId::class);
+        $this->keyId->method('value')->willReturn(Uuid::uuid4()->toString());
+
+        $this->clientId = new ClientId(Uuid::uuid4()->toString());
+        $this->publicKey = $this->createMock(PublicKey::class);
+        $this->publicKey->method('value')->willReturn('ssh-rsa AAAAB3NzaC1yc2EAAAAD test-key');
+
+        $this->validFrom = new DateTimeImmutable();
+        $this->validUntil = (new DateTimeImmutable())->modify('+1 year');
+
+        $this->key = new Key(
+            $this->keyId,
+            $this->clientId,
+            $this->publicKey,
+            1,
+            $this->validFrom,
+            $this->validUntil
+        );
+    }
+
+    public function testKeyCreation(): void
+    {
+        $this->assertEquals($this->keyId->value(), $this->key->keyId());
+        $this->assertEquals($this->clientId->value(), $this->key->clientId());
+        $this->assertEquals($this->publicKey->value(), $this->key->publicKey());
+        $this->assertEquals(1, $this->key->version());
+        $this->assertEquals($this->validFrom, $this->key->validFrom());
+        $this->assertEquals($this->validUntil, $this->key->validUntil());
+        $this->assertFalse($this->key->isRevoked());
+        $this->assertNull($this->key->revokedAt());
+    }
+
+    public function testRevokeKey(): void
+    {
+        $this->assertFalse($this->key->isRevoked());
+        $this->assertNull($this->key->revokedAt());
+
+        $this->key->revoke();
+
+        $this->assertTrue($this->key->isRevoked());
+        $this->assertInstanceOf(DateTimeImmutable::class, $this->key->revokedAt());
+    }
+}

--- a/tests/Unit/Domains/Vault/Key/ValueObjects/ClientIdTest.php
+++ b/tests/Unit/Domains/Vault/Key/ValueObjects/ClientIdTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace JuniorFontenele\LaravelVaultServer\Tests\Unit\Domains\Vault\Key\ValueObjects;
+
+use JuniorFontenele\LaravelVaultServer\Domains\Vault\Key\Exceptions\ClientIdException;
+use JuniorFontenele\LaravelVaultServer\Domains\Vault\Key\ValueObjects\ClientId;
+use JuniorFontenele\LaravelVaultServer\Tests\TestCase;
+use Ramsey\Uuid\Uuid;
+
+class ClientIdTest extends TestCase
+{
+    public function testCreateClientIdWithValidUuid(): void
+    {
+        $uuid = Uuid::uuid4()->toString();
+        $clientId = new ClientId($uuid);
+
+        $this->assertEquals($uuid, $clientId->value());
+        $this->assertEquals($uuid, (string) $clientId);
+    }
+
+    public function testCreateClientIdWithInvalidUuidThrowsException(): void
+    {
+        $this->expectException(ClientIdException::class);
+
+        new ClientId('not-a-valid-uuid');
+    }
+}


### PR DESCRIPTION
Introduce unit tests for various value objects and exceptions while correcting the token verification logic to ensure it uses the plain value consistently.